### PR TITLE
[RFC][NI] Added error when color function does not find desired color

### DIFF
--- a/src/styles/_common/_colors.scss
+++ b/src/styles/_common/_colors.scss
@@ -112,6 +112,12 @@ $primary-color-key: 'primary' !default;
   // Get the color variant
   @if $color-spectrum {
     $color: map-get($color-spectrum, $variant);
+
+    @if not($color) {
+      @error "Color `#{$variant}` does not exist in spectrum `#{$name}`";
+    }
+  } @else {
+    @error "Spectrum `#{$name}` does not exist";
   }
 
   @return $color;


### PR DESCRIPTION
Throws an error when somebody calls the `color` function with values that do not exist in pallette