### PR TITLE
[RFC][NI]Old set of colors added in order to support old version and Uniq 2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "uniq",
-  "version": "2.0.77",
+  "version": "2.0.78",
   "description": "Internal CSS Framework/Toolkit used @ Uniplaces",
   "main": [
     "src/styles/**/*",

--- a/src/styles/_common/_colors.scss
+++ b/src/styles/_common/_colors.scss
@@ -126,6 +126,11 @@ $palette: (
     'border': #d1d5da,
     'active': #66d5ff,
     'item-hover': #dbf5ff
+  ),
+  'medium-gray': ( //OLD colors. Do not use this string map. This will be removed after old UNIQ deprecation
+    'primary': #cccccc,
+    'medium': #e0e0e0,
+    'light': #eaeaea
   )
 );
 


### PR DESCRIPTION
Old set of colors added in order to support old version and Uniq 2 version on same Ember projects.
This can be removed after the complete deprecation of Uniq 1.x.x. 