### PR TITLE
[RFC][NI]fixed appearance on firefox

### DIFF
--- a/src/styles/_components/_inputs.scss
+++ b/src/styles/_components/_inputs.scss
@@ -590,6 +590,7 @@ $checkbox-size: 32px;
 
     will-change: border;
     -webkit-appearance: none;
+    -moz-appearance: none;
     appearance: none;
 
     &:-moz-focusring {


### PR DESCRIPTION
Fixed select appearence:

Firefox before:
<img width="500" alt="screenshot 2017-05-10 12 29 10" src="https://cloud.githubusercontent.com/assets/1219081/25896748/553bfcea-357d-11e7-87b5-7c14c15282a6.png">

Firefox after 
<img width="214" alt="screenshot 2017-05-10 12 35 46" src="https://cloud.githubusercontent.com/assets/1219081/25896756/6181610c-357d-11e7-9612-09e99d3292a5.png">


