### PR TITLE
[RFC][NI]new anchor show-more with caret

### DIFF
--- a/src/styles/_common/_typography.scss
+++ b/src/styles/_common/_typography.scss
@@ -65,7 +65,7 @@ $small: em(9px);
     @include font("IntervalNextReg");
     color: color('primary');
     text-decoration: none;
-    
+
     &:hover {
         cursor: pointer;
         text-decoration: underline;
@@ -78,6 +78,52 @@ $small: em(9px);
     }
     &--alternative {
         color: color('anchor', 'alternative');
+    }
+}
+
+@mixin anchor-show-more($border-color: color('primary'), $bg-color: color('primary', 'highlight')) {
+    @include anchor();
+    padding-right: 1em;
+    position: relative;
+    display: inline-block;
+
+    &:before {
+        content: '';
+        position: absolute;
+        top: 0.5em;
+        right: -1em;
+        border-top: 0.438em solid $border-color;
+        border-left: 0.438em solid transparent;
+        border-right: 0.438em solid transparent;
+    }
+
+    &:after {
+        content: '';
+        position: absolute;
+        right: -0.938em;
+        top: 0.5em;
+        border-top: 0.375em solid $bg-color;
+        border-left: 0.375em solid transparent;
+        border-right: 0.375em solid transparent;
+    }
+
+    &--visible {
+        &:before {
+            top: 0.5em;
+            right: -0.938em;
+            border-bottom: 0.438em solid $border-color;
+            border-left: 0.438em solid transparent;
+            border-right: 0.438em solid transparent;
+            border-top: none;
+        }
+        &:after {
+            right: -0.875em;
+            top: 0.563em;
+            border-bottom: 0.375em solid $bg-color;
+            border-left: 0.375em solid transparent;
+            border-right: 0.375em solid transparent;
+            border-top: none;
+        }
     }
 }
 


### PR DESCRIPTION
Added new anchor mixin for the "Show more / Show less" anchors to toggle content.

**Result**
<img width="403" alt="screenshot 2017-05-11 16 11 04" src="https://cloud.githubusercontent.com/assets/1219081/25956959/16ee9284-3665-11e7-821e-d51f51bbac70.png">
<img width="325" alt="screenshot 2017-05-11 16 11 12" src="https://cloud.githubusercontent.com/assets/1219081/25956970/1c86414c-3665-11e7-932e-f715f3b8d7ca.png">

**Notes**:

- it receives border-color and background-color as option.
- Units in "em" to scale with font-size.

**Example of usage:**
<a href="#" class="show-more {{if visible 'show-more--visible' ''}}" {{action (toggle "visible" this)}}>Show {{if visible 'less' 'more'}}</a>




