### PR TITLE
[RFC][NI] Add small uni-checkbox and uni-input-range

### DIFF
--- a/src/styles/_components/_inputs.scss
+++ b/src/styles/_components/_inputs.scss
@@ -260,6 +260,32 @@ $checkbox-size: 32px;
             }
         }
     }
+
+    &--small {
+        + label {
+            padding-left: $checkbox-size !important;
+            color: #667485;
+            font-size: em(14px);
+
+            &::before {
+                width: 20px;
+                height: 20px;
+            }
+
+            & > svg {
+                width: 12px;
+                height: 9px;
+                top: calc(50% - 4px);
+                left: 5px !important;
+            }
+        }
+
+        &:checked {
+            + label {
+                color: color("primary");
+            }
+        }
+    }
 }
 
 @mixin radio-button() {


### PR DESCRIPTION
# What this does?
- Adds a `--small` modifier to `uni-checkbox`
- Adds a `-small` modifier to `uni-input-range`

# Screenshots
<img width="177" alt="screen shot 2018-01-18 at 10 49 49" src="https://user-images.githubusercontent.com/2593480/35094883-92591f76-fc3e-11e7-9684-913949441b90.png">

# Notes
I've used some numbers that are not multiples from 4 due to the svg we already have not being a perfect square. Also, the checkbox size is `20x20` and this means we're also loosing this proportion in the small checkbox