### PR TITLE
Allow font swap

### DIFF
--- a/src/styles/_common/_fonts.scss
+++ b/src/styles/_common/_fonts.scss
@@ -43,6 +43,7 @@ $base-font-size: 16px; // Default font-size
 	@font-face {
 		font-family: quote($name);
 		font-style: $style;
+		font-display: swap;
 		font-weight: $weight;
 		src: $src;
 	}


### PR DESCRIPTION
This will tell the browser to render the page and then swap the font when it's available.

![Screenshot 2019-03-20 at 11 40 33](https://user-images.githubusercontent.com/1071148/54681750-0e660f00-4b05-11e9-8da7-db62a6748a89.png)
As you can see in the previous image, the left profiling screenshot doesn't have the "Ensure text remain visible ..." warning